### PR TITLE
[chore] : global-exception-filter 적용

### DIFF
--- a/src/lib/global-exception-filter.ts
+++ b/src/lib/global-exception-filter.ts
@@ -1,0 +1,54 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  Logger,
+} from '@nestjs/common';
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+
+    const location = this.getErrorOrigin(exception);
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const resBody = exception.getResponse();
+
+      this.logger.warn(
+        `[${request.method}] ${request.url}\ncode: ${status}\ncontent: ${JSON.stringify(resBody)}\nlocation: ${location}`,
+      );
+
+      response.status(status).json(resBody);
+    } else {
+      this.logger.error(
+        `[${request.method}] ${request.url}\ncode: 500\ncontent: ${String(exception)}\nlocation: ${location}`,
+      );
+
+      response.status(500).json({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
+    }
+  }
+
+  private getErrorOrigin(exception: unknown): string {
+    const stack =
+      exception instanceof Error ? exception.stack : new Error().stack;
+    if (!stack) return 'Unknown origin';
+
+    const lines = stack.split('\n');
+
+    const userCodeLine = lines.find(
+      (line) => !line.includes('node_modules') && line.includes('/src/'),
+    );
+
+    return userCodeLine?.trim() ?? lines[1]?.trim() ?? 'Unknown origin';
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module'; // 앱의 루트 모듈 (전체 앱의
 import { ClassSerializerInterceptor } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { GlobalExceptionFilter } from './lib/global-exception-filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -27,6 +28,8 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
+
+  app.useGlobalFilters(new GlobalExceptionFilter());
 
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
express 에서의 globalErrorHandler 같은 걸 대강 만들어봤습니다.. 참을 수 없어서...

resonse 는 NestJS 가 주는거 그대로 던지게 되어 있고요
(메시지를 일괄 처리 해주지는 않습니다)
대신 어디에서 어떤 에러가 난건지 logger로 알려줍니다......


테스트 코드에서도 쓰고 싶으시다면 
`app.useGlobalFilters(new GlobalExceptionFilter());`

이걸 `app.init()` 앞에 넣어주시면 됩니다...